### PR TITLE
Enable debug logging

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -38,6 +38,8 @@ npm run dev
 
 🌐 **API running at:** `http://localhost:4000`
 
+To enable full debug logging, set `LOG_LEVEL=debug` in the `.env` file or as an environment variable before starting the server.
+
 ---
 
 ## 🔐 Authentication

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ npm run dev
 
 🌐 **API rodando em:** `http://localhost:4000`
 
+Para habilitar logs completos de debug, defina `LOG_LEVEL=debug` no arquivo `.env` ou nas variáveis de ambiente antes de iniciar o servidor.
+
 ---
 
 ## 🔐 Autenticação

--- a/app.js
+++ b/app.js
@@ -6,7 +6,9 @@ const autoload = require("@fastify/autoload");
 const fastify = require("fastify");
 
 const app = fastify({
-  logger: false,
+  logger: {
+    level: process.env.LOG_LEVEL || "debug",
+  },
 });
 
 app.register(autoload, {

--- a/src/plugins/config.js
+++ b/src/plugins/config.js
@@ -44,7 +44,7 @@ module.exports = fp(
 
       // Logging
       logging: {
-        level: process.env.LOG_LEVEL || "info",
+        level: process.env.LOG_LEVEL || "debug",
         toFile: process.env.LOG_TO_FILE === "true",
       },
 
@@ -85,6 +85,9 @@ module.exports = fp(
 
     // Decora o Fastify com as configurações
     app.decorate("config", config);
+
+    // Ajusta o nível do logger conforme configuração
+    app.log.level = config.logging.level;
 
     // Log das configurações na inicialização
     app.log.info("📋 Configurações carregadas:", {


### PR DESCRIPTION
## Summary
- enable Fastify logger with configurable level defaulting to debug
- align config plugin to honor LOG_LEVEL and set runtime logger level
- document how to activate debug logs in both READMEs

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7074d060c8321a527e328c72f0f77