### PR TITLE
feat: upload pdfs to s3 storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@fastify/static": "^8.2.0",
     "bcrypt": "^6.0.0",
     "dotenv": "^16.4.5",
+    "@aws-sdk/client-s3": "^3.637.0",
     "fastify": "^5.3.3",
     "fastify-cli": "^7.4.0",
     "fastify-guard": "^3.0.1",

--- a/src/plugins/config.js
+++ b/src/plugins/config.js
@@ -64,6 +64,16 @@ module.exports = fp(
         compression: process.env.ENABLE_COMPRESSION !== "false",
       },
 
+      // Storage (S3/MinIO)
+      storage: {
+        endpoint: process.env.S3_ENDPOINT || "http://localhost:9000",
+        region: process.env.S3_REGION || "us-east-1",
+        bucket: process.env.S3_BUCKET || "papyrus",
+        accessKey: process.env.S3_ACCESS_KEY || "",
+        secretKey: process.env.S3_SECRET_KEY || "",
+        publicUrl: process.env.S3_PUBLIC_URL || "",
+      },
+
       // API Keys administrativas (para seeds/bootstrap)
       adminKeys: process.env.ADMIN_API_KEYS
         ? process.env.ADMIN_API_KEYS.split(",").map((keyPair) => {
@@ -94,6 +104,7 @@ module.exports = fp(
       pdfEngine: config.pdf.engine,
       cacheEnabled: config.cache.templates,
       compressionEnabled: config.performance.compression,
+      storageEndpoint: config.storage.endpoint,
     });
   },
   {
@@ -118,6 +129,10 @@ function validateConfig(config, app) {
 
   if (config.pdf.timeout < 5000) {
     errors.push("⚠️ PDF_TIMEOUT muito baixo, recomendado >= 5000ms");
+  }
+
+  if (!config.storage.bucket) {
+    errors.push("❌ S3_BUCKET é obrigatório");
   }
 
   // Log de erros ou warnings

--- a/src/routes/pdf/index.js
+++ b/src/routes/pdf/index.js
@@ -107,17 +107,13 @@ module.exports = async (app) => {
           request.body
         );
 
-        // Headers para download
-        reply
-          .type(result.contentType)
-          .header(
-            "Content-Disposition",
-            `attachment; filename="${result.filename}"`
-          )
-          .header("Content-Length", result.buffer.length)
-          .header("X-PDF-Language", language);
+        // Faz upload do PDF para o storage
+        const url = await app.storageService.uploadPDF(
+          result.buffer,
+          result.filename
+        );
 
-        return reply.send(result.buffer);
+        return reply.send({ url });
       } catch (error) {
         app.log.error("Erro ao gerar PDF:", error);
 

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const fp = require("fastify-plugin");
+const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
+
+module.exports = fp(
+  async (app) => {
+    const {
+      endpoint,
+      region,
+      bucket,
+      accessKey,
+      secretKey,
+      publicUrl,
+    } = app.config.storage;
+
+    const s3 = new S3Client({
+      endpoint,
+      region,
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: accessKey,
+        secretAccessKey: secretKey,
+      },
+    });
+
+    async function uploadPDF(buffer, filename) {
+      const key = filename;
+
+      await s3.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: buffer,
+          ContentType: "application/pdf",
+        })
+      );
+
+      return `${publicUrl}/${key}`;
+    }
+
+    app.decorate("storageService", {
+      uploadPDF,
+    });
+
+    app.log.info("\ud83d\udce6 Storage service carregado");
+  },
+  { name: "storage-service", dependencies: ["config"] }
+);


### PR DESCRIPTION
## Summary
- add S3 config and dependency
- introduce storage service using AWS SDK
- upload generated PDFs to S3 and return public URL

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a715c9cfb083218bb7a3adea6f0076