### PR TITLE
Block external assets during PDF generation

### DIFF
--- a/src/services/pdfEngine.js
+++ b/src/services/pdfEngine.js
@@ -167,19 +167,14 @@ module.exports = fp(
         await page.setRequestInterception(true);
         page.on("request", (request) => {
           const resourceType = request.resourceType();
+          const url = request.url();
 
-          // Bloqueia recursos que não precisamos para PDF
-          if (["image", "media", "font", "stylesheet"].includes(resourceType)) {
-            // Permite apenas se for local ou essencial
-            const url = request.url();
-            if (
-              url.startsWith("data:") ||
-              url.startsWith("blob:") ||
-              url.includes("base64")
-            ) {
+          // Bloqueia recursos não essenciais para geração do PDF
+          if (["image", "media", "stylesheet"].includes(resourceType)) {
+            if (url.startsWith("data:") || url.startsWith("blob:")) {
               request.continue();
             } else {
-              request.continue(); // Por enquanto permite tudo, pode filtrar depois
+              request.abort();
             }
           } else {
             request.continue();


### PR DESCRIPTION
## Summary
- abort external image, media, and stylesheet requests during PDF rendering

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a847d7d32c83218c9ab57764e58e18