### PR TITLE
feat: emulate print media before rendering

### DIFF
--- a/src/services/pdfEngine.js
+++ b/src/services/pdfEngine.js
@@ -82,6 +82,9 @@ module.exports = fp(
         // Otimiza a página para melhor renderização
         await optimizePage(page, pdfConfig);
 
+        // Garante aplicação dos estilos de impressão
+        await page.emulateMediaType("print");
+
         // Define o HTML na página
         await page.setContent(htmlContent, {
           waitUntil: ["domcontentloaded", "networkidle0"],


### PR DESCRIPTION
## Summary
- ensure Puppeteer uses print media so `@media print` styles apply to PDF output

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`
- `node -e "..."` *(fails: Missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a84a0280f88321b770c757a2dcaf15