### PR TITLE
feat: block external assets during PDF generation

### DIFF
--- a/src/services/pdfEngine.js
+++ b/src/services/pdfEngine.js
@@ -185,19 +185,18 @@ module.exports = fp(
         await page.setRequestInterception(true);
         page.on("request", (request) => {
           const resourceType = request.resourceType();
+          const url = request.url();
 
-          // Bloqueia recursos que não precisamos para PDF
+          const isLocal =
+            url.startsWith("data:") ||
+            url.startsWith("blob:") ||
+            url.includes("base64");
+
           if (["image", "media", "font", "stylesheet"].includes(resourceType)) {
-            // Permite apenas se for local ou essencial
-            const url = request.url();
-            if (
-              url.startsWith("data:") ||
-              url.startsWith("blob:") ||
-              url.includes("base64")
-            ) {
+            if (isLocal) {
               request.continue();
             } else {
-              request.continue(); // Por enquanto permite tudo, pode filtrar depois
+              request.abort();
             }
           } else {
             request.continue();


### PR DESCRIPTION
## Summary
- block external image, media, font, and stylesheet requests during PDF generation

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`
- `time node test_pdf.js` *(fails: missing libatk-1.0.so.0; apt update forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c71ad242e88321926cacb1493a6e6f