### PR TITLE
feat: stream PDFs directly from storage

### DIFF
--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -1,7 +1,11 @@
 "use strict";
 
 const fp = require("fastify-plugin");
-const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
+const {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+} = require("@aws-sdk/client-s3");
 
 module.exports = fp(
   async (app) => {
@@ -39,8 +43,50 @@ module.exports = fp(
       return `${publicUrl}/${key}`;
     }
 
+    async function getPDFStream(key) {
+      if (!key) {
+        throw new Error("Storage key is required");
+      }
+
+      try {
+        const response = await s3.send(
+          new GetObjectCommand({
+            Bucket: bucket,
+            Key: key,
+          })
+        );
+
+        if (!response?.Body) {
+          const emptyStreamError = new Error("PDF stream not available");
+          emptyStreamError.code = "PDF_STREAM_EMPTY";
+          throw emptyStreamError;
+        }
+
+        return {
+          stream: response.Body,
+          contentType: response.ContentType || "application/pdf",
+          contentLength: response.ContentLength,
+          lastModified: response.LastModified,
+          etag: response.ETag,
+          key,
+        };
+      } catch (error) {
+        if (
+          error?.name === "NoSuchKey" ||
+          error?.$metadata?.httpStatusCode === 404
+        ) {
+          const notFoundError = new Error("PDF not found");
+          notFoundError.code = "PDF_NOT_FOUND";
+          throw notFoundError;
+        }
+
+        throw error;
+      }
+    }
+
     app.decorate("storageService", {
       uploadPDF,
+      getPDFStream,
     });
 
     app.log.info("\ud83d\udce6 Storage service carregado");


### PR DESCRIPTION
## Summary
- add a GET /pdf/view/:id route that streams PDFs inline with translated error responses
- expose a storage service helper to read PDF objects from S3-compatible storage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c84df9a7648321be88099551731ed5