### PR TITLE
Add formatting helpers for Brazilian contact data

### DIFF
--- a/src/plugins/handlebars.js
+++ b/src/plugins/handlebars.js
@@ -49,6 +49,33 @@ module.exports = fp(
      * Registra helpers customizados para os templates
      */
     function registerHelpers() {
+      function extractDigits(value) {
+        if (value === null || value === undefined) {
+          return "";
+        }
+
+        return value.toString().replace(/\D+/g, "");
+      }
+
+      function formatWithMask(digits, mask) {
+        let result = "";
+        let digitIndex = 0;
+
+        for (const char of mask) {
+          if (char === "#") {
+            if (digitIndex >= digits.length) {
+              break;
+            }
+            result += digits[digitIndex];
+            digitIndex += 1;
+          } else {
+            result += char;
+          }
+        }
+
+        return result;
+      }
+
       // Helper para formatação de moeda
       handlebars.registerHelper("currency", function (value) {
         if (!value && value !== 0) return "R$ 0,00";
@@ -123,6 +150,77 @@ module.exports = fp(
           minimumFractionDigits: safeDecimals,
           maximumFractionDigits: safeDecimals,
         }).format(parseFloat(value) || 0);
+      });
+
+      // Helper para formatação de telefone
+      handlebars.registerHelper("phone", function (value) {
+        const digits = extractDigits(value);
+
+        if (!digits) {
+          return "";
+        }
+
+        if (digits.length > 11) {
+          const countryCode = digits.slice(0, digits.length - 11);
+          const national = digits.slice(-11);
+          const formattedNational = formatWithMask(
+            national,
+            "(##) #####-####"
+          );
+          return `+${countryCode} ${formattedNational}`.trim();
+        }
+
+        if (digits.length === 11) {
+          return formatWithMask(digits, "(##) #####-####");
+        }
+
+        if (digits.length === 10) {
+          return formatWithMask(digits, "(##) ####-####");
+        }
+
+        if (digits.length === 9) {
+          return formatWithMask(digits, "#####-####");
+        }
+
+        if (digits.length === 8) {
+          return formatWithMask(digits, "####-####");
+        }
+
+        return value || "";
+      });
+
+      // Helper para formatação de documentos (CPF/CNPJ)
+      handlebars.registerHelper("document", function (value) {
+        const digits = extractDigits(value);
+
+        if (!digits) {
+          return "";
+        }
+
+        if (digits.length === 14) {
+          return formatWithMask(digits, "##.###.###/####-##");
+        }
+
+        if (digits.length === 11) {
+          return formatWithMask(digits, "###.###.###-##");
+        }
+
+        return value || "";
+      });
+
+      // Helper para formatação de CEP
+      handlebars.registerHelper("cep", function (value) {
+        const digits = extractDigits(value);
+
+        if (!digits) {
+          return "";
+        }
+
+        if (digits.length >= 8) {
+          return formatWithMask(digits.slice(0, 8), "#####-###");
+        }
+
+        return value || "";
       });
 
       // Helper para loops com index

--- a/src/templates/business/budget-premium.en-US.hbs
+++ b/src/templates/business/budget-premium.en-US.hbs
@@ -133,7 +133,8 @@ supportedLanguages: en-US, pt-BR
           <div class="company-name">
             <h1>{{budget.company.name}}</h1>
             <div class="company-details">
-              {{#if budget.company.cnpj}}Tax ID: {{budget.company.cnpj}}{{/if}}
+              {{#if budget.company.cnpj}}Tax ID:
+                {{document budget.company.cnpj}}{{/if}}
               {{#if budget.company.address}} | {{budget.company.address}}{{/if}}
             </div>
           </div>
@@ -162,7 +163,7 @@ supportedLanguages: en-US, pt-BR
                 <span class="detail-label">{{#ifCond
                     budget.client.document.length ">" 14
                   }}Tax ID{{else}}ID{{/ifCond}}:</span>
-                <span>{{budget.client.document}}</span>
+                <span>{{document budget.client.document}}</span>
               </div>
             {{/if}}
             {{#if budget.client.email}}
@@ -174,7 +175,7 @@ supportedLanguages: en-US, pt-BR
             {{#if budget.client.phone}}
               <div class="detail-item">
                 <span class="detail-label">Phone:</span>
-                <span>{{budget.client.phone}}</span>
+                <span>{{phone budget.client.phone}}</span>
               </div>
             {{/if}}
           </div>

--- a/src/templates/business/budget-premium.hbs
+++ b/src/templates/business/budget-premium.hbs
@@ -166,7 +166,8 @@ supportedLanguages: pt-BR
           <div class="company-name">
             <h1>{{budget.company.name}}</h1>
             <div class="company-details">
-              {{#if budget.company.cnpj}}CNPJ: {{budget.company.cnpj}}{{/if}}
+              {{#if budget.company.cnpj}}CNPJ:
+                {{document budget.company.cnpj}}{{/if}}
               {{#if budget.company.address}} | {{budget.company.address}}{{/if}}
             </div>
           </div>
@@ -194,7 +195,7 @@ supportedLanguages: pt-BR
                 <span class="detail-label">{{#ifCond
                     budget.client.document.length ">" 14
                   }}CNPJ{{else}}CPF{{/ifCond}}:</span>
-                <span>{{budget.client.document}}</span>
+                <span>{{document budget.client.document}}</span>
               </div>
             {{/if}}
             {{#if budget.client.email}}
@@ -206,7 +207,7 @@ supportedLanguages: pt-BR
             {{#if budget.client.phone}}
               <div class="detail-item">
                 <span class="detail-label">Telefone:</span>
-                <span>{{budget.client.phone}}</span>
+                <span>{{phone budget.client.phone}}</span>
               </div>
             {{/if}}
           </div>
@@ -307,7 +308,7 @@ supportedLanguages: pt-BR
                     d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"
                   />
                 </svg>
-                <span>{{budget.company.phone}}</span>
+                <span>{{phone budget.company.phone}}</span>
               </div>
             {{/if}}
             {{#if budget.company.email}}

--- a/src/templates/business/budget.hbs
+++ b/src/templates/business/budget.hbs
@@ -93,11 +93,11 @@ author: Papyrus Team
               {{#if budget.company.address}}<div
                 >{{budget.company.address}}</div>{{/if}}
               {{#if budget.company.phone}}<div>Tel:
-                  {{budget.company.phone}}</div>{{/if}}
+                  {{phone budget.company.phone}}</div>{{/if}}
               {{#if budget.company.email}}<div>E-mail:
                   {{budget.company.email}}</div>{{/if}}
               {{#if budget.company.cnpj}}<div>CNPJ:
-                  {{budget.company.cnpj}}</div>{{/if}}
+                  {{document budget.company.cnpj}}</div>{{/if}}
             </div>
           </div>
         {{/if}}
@@ -110,14 +110,14 @@ author: Papyrus Team
               {{#if budget.client.address}}<div
                 >{{budget.client.address}}</div>{{/if}}
               {{#if budget.client.phone}}<div>Tel:
-                  {{budget.client.phone}}</div>{{/if}}
+                  {{phone budget.client.phone}}</div>{{/if}}
               {{#if budget.client.email}}<div>E-mail:
                   {{budget.client.email}}</div>{{/if}}
               {{#if budget.client.document}}
                 <div>{{#ifCond
                     budget.client.document.length ">" 14
                   }}CNPJ{{else}}CPF{{/ifCond}}:
-                  {{budget.client.document}}</div>
+                  {{document budget.client.document}}</div>
               {{/if}}
             </div>
           </div>

--- a/src/templates/medical/anamnesis.hbs
+++ b/src/templates/medical/anamnesis.hbs
@@ -147,7 +147,7 @@
             {{#if doctor.phone}}
               <div class="info-item">
                 <span class="info-label">Telefone:</span>
-                <span class="info-value">{{doctor.phone}}</span>
+                <span class="info-value">{{phone doctor.phone}}</span>
               </div>
             {{/if}}
           </div>
@@ -200,7 +200,7 @@
           <div class="form-field">
             <label>CPF:</label>
             {{#if patient.document}}
-              <div class="field-value">{{patient.document}}</div>
+              <div class="field-value">{{document patient.document}}</div>
             {{else}}
               <div class="field-input"></div>
             {{/if}}
@@ -208,7 +208,7 @@
           <div class="form-field">
             <label>Telefone:</label>
             {{#if patient.phone}}
-              <div class="field-value">{{patient.phone}}</div>
+              <div class="field-value">{{phone patient.phone}}</div>
             {{else}}
               <div class="field-input"></div>
             {{/if}}

--- a/src/templates/medical/prescription.hbs
+++ b/src/templates/medical/prescription.hbs
@@ -132,7 +132,7 @@ author: Papyrus Team
               <div><strong>Clínica:</strong> {{doctor.clinic}}</div>
             {{/if}}
             {{#if doctor.phone}}
-              <div><strong>Telefone:</strong> {{doctor.phone}}</div>
+              <div><strong>Telefone:</strong> {{phone doctor.phone}}</div>
             {{/if}}
             {{#if doctor.address}}
               <div style="flex-basis: 100%">


### PR DESCRIPTION
## Summary
- add Handlebars helpers to format phone numbers, CPF/CNPJ and CEP before rendering templates
- update business and medical templates (pt-BR and en-US) to output formatted phone numbers and document identifiers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d543642cb483218c4cfded037a8405