### PR TITLE
Adicionar formatações para contatos e valores brasileiros

### DIFF
--- a/src/plugins/handlebars.js
+++ b/src/plugins/handlebars.js
@@ -4,6 +4,13 @@ const fp = require("fastify-plugin");
 const handlebars = require("handlebars");
 const fs = require("fs").promises;
 const path = require("path");
+const {
+  formatCurrencyBRL,
+  formatPhoneNumber,
+  formatCnpj,
+  formatCpfCnpj,
+  formatCep,
+} = require("../utils/formatters");
 
 module.exports = fp(
   async (app) => {
@@ -51,16 +58,27 @@ module.exports = fp(
     function registerHelpers() {
       // Helper para formatação de moeda
       handlebars.registerHelper("currency", function (value) {
-        if (!value && value !== 0) return "R$ 0,00";
+        return formatCurrencyBRL(value);
+      });
 
-        const numValue = parseFloat(value) || 0;
+      // Helper para formatação de telefone
+      handlebars.registerHelper("phone", function (value) {
+        return formatPhoneNumber(value);
+      });
 
-        return new Intl.NumberFormat("pt-BR", {
-          style: "currency",
-          currency: "BRL",
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2,
-        }).format(numValue);
+      // Helper para formatação de CNPJ
+      handlebars.registerHelper("cnpj", function (value) {
+        return formatCnpj(value);
+      });
+
+      // Helper para formatação de CPF/CNPJ automático
+      handlebars.registerHelper("cpfCnpj", function (value) {
+        return formatCpfCnpj(value);
+      });
+
+      // Helper para formatação de CEP
+      handlebars.registerHelper("cep", function (value) {
+        return formatCep(value);
       });
 
       // Helper para formatação de data

--- a/src/templates/business/budget-premium.js
+++ b/src/templates/business/budget-premium.js
@@ -1,4 +1,7 @@
 const { jsPDF } = require("jspdf");
+const { formatCurrencyBRL, formatPhoneNumber, formatCnpj, formatCep } = require(
+  "../../utils/formatters"
+);
 
 async function generateBudgetPremium(data) {
   const doc = new jsPDF({
@@ -225,9 +228,11 @@ async function generateBudgetPremium(data) {
   doc.setTextColor(...colors.secondary);
   let companyDetails = [];
   if (data.budget.company?.cnpj)
-    companyDetails.push(`CNPJ: ${data.budget.company.cnpj}`);
+    companyDetails.push(`CNPJ: ${formatCnpj(data.budget.company.cnpj)}`);
   if (data.budget.company?.address)
     companyDetails.push(data.budget.company.address);
+  if (data.budget.company?.cep)
+    companyDetails.push(`CEP: ${formatCep(data.budget.company.cep)}`);
   if (companyDetails.length > 0) {
     doc.text(companyDetails.join(" • "), xLogo, y + 9);
   }
@@ -307,7 +312,7 @@ async function generateBudgetPremium(data) {
 
     if (data.budget.client.phone) {
       doc.text(
-        `Contato: ${data.budget.client.phone}`,
+        `Contato: ${formatPhoneNumber(data.budget.client.phone)}`,
         margin.left + 4,
         yClient + 4
       );
@@ -411,8 +416,9 @@ async function generateBudgetPremium(data) {
 
       // Valor unitário
       const unitPrice = item.unitPrice || 0;
+      const formattedUnitPrice = formatCurrencyBRL(unitPrice);
       doc.text(
-        `R$ ${unitPrice.toFixed(2)}`,
+        formattedUnitPrice,
         colPositions.unitPrice + colWidths.unitPrice - 3,
         y + 5,
         { align: "right" }
@@ -422,8 +428,9 @@ async function generateBudgetPremium(data) {
       const rowTotal = qty * unitPrice;
       doc.setFont("helvetica", "bold");
       doc.setTextColor(...colors.success);
+      const formattedRowTotal = formatCurrencyBRL(rowTotal);
       doc.text(
-        `R$ ${rowTotal.toFixed(2)}`,
+        formattedRowTotal,
         colPositions.total + colWidths.total - 3,
         y + 5,
         { align: "right" }
@@ -482,7 +489,8 @@ async function generateBudgetPremium(data) {
       (sum, item) => sum + (item.quantity || 0) * (item.unitPrice || 0),
       0
     ) || 0;
-  doc.text(`R$ ${subtotal.toFixed(2)}`, pageWidth - margin.right - 2, y + 5, {
+  const formattedSubtotal = formatCurrencyBRL(subtotal);
+  doc.text(formattedSubtotal, pageWidth - margin.right - 2, y + 5, {
     align: "right",
   });
   y += 8;
@@ -495,8 +503,9 @@ async function generateBudgetPremium(data) {
 
     doc.setTextColor(...colors.danger);
     doc.setFont("helvetica", "bold");
+    const formattedDiscount = formatCurrencyBRL(data.budget.discount);
     doc.text(
-      `- R$ ${data.budget.discount.toFixed(2)}`,
+      `- ${formattedDiscount}`,
       pageWidth - margin.right - 2,
       y + 5,
       { align: "right" }
@@ -520,7 +529,8 @@ async function generateBudgetPremium(data) {
   doc.setFontSize(8);
   doc.setTextColor(255, 255, 255);
   doc.text("VALOR TOTAL:", totalsX, y + 7);
-  doc.text(`R$ ${finalTotal.toFixed(2)}`, pageWidth - margin.right - 2, y + 7, {
+  const formattedFinalTotal = formatCurrencyBRL(finalTotal);
+  doc.text(formattedFinalTotal, pageWidth - margin.right - 2, y + 7, {
     align: "right",
   });
 
@@ -634,7 +644,7 @@ async function generateBudgetPremium(data) {
 
   let footerText = [];
   if (data.budget.company?.phone)
-    footerText.push(` ${data.budget.company.phone}`);
+    footerText.push(` ${formatPhoneNumber(data.budget.company.phone)}`);
   if (data.budget.company?.email)
     footerText.push(` ${data.budget.company.email}`);
   if (data.budget.company?.website)

--- a/src/templates/business/budget.hbs
+++ b/src/templates/business/budget.hbs
@@ -93,11 +93,13 @@ author: Papyrus Team
               {{#if budget.company.address}}<div
                 >{{budget.company.address}}</div>{{/if}}
               {{#if budget.company.phone}}<div>Tel:
-                  {{budget.company.phone}}</div>{{/if}}
+                  {{phone budget.company.phone}}</div>{{/if}}
               {{#if budget.company.email}}<div>E-mail:
                   {{budget.company.email}}</div>{{/if}}
+              {{#if budget.company.cep}}<div>CEP:
+                  {{cep budget.company.cep}}</div>{{/if}}
               {{#if budget.company.cnpj}}<div>CNPJ:
-                  {{budget.company.cnpj}}</div>{{/if}}
+                  {{cnpj budget.company.cnpj}}</div>{{/if}}
             </div>
           </div>
         {{/if}}
@@ -110,14 +112,16 @@ author: Papyrus Team
               {{#if budget.client.address}}<div
                 >{{budget.client.address}}</div>{{/if}}
               {{#if budget.client.phone}}<div>Tel:
-                  {{budget.client.phone}}</div>{{/if}}
+                  {{phone budget.client.phone}}</div>{{/if}}
               {{#if budget.client.email}}<div>E-mail:
                   {{budget.client.email}}</div>{{/if}}
+              {{#if budget.client.cep}}<div>CEP:
+                  {{cep budget.client.cep}}</div>{{/if}}
               {{#if budget.client.document}}
                 <div>{{#ifCond
                     budget.client.document.length ">" 14
                   }}CNPJ{{else}}CPF{{/ifCond}}:
-                  {{budget.client.document}}</div>
+                  {{cpfCnpj budget.client.document}}</div>
               {{/if}}
             </div>
           </div>

--- a/src/templates/medical/anamnesis.hbs
+++ b/src/templates/medical/anamnesis.hbs
@@ -147,7 +147,13 @@
             {{#if doctor.phone}}
               <div class="info-item">
                 <span class="info-label">Telefone:</span>
-                <span class="info-value">{{doctor.phone}}</span>
+                <span class="info-value">{{phone doctor.phone}}</span>
+              </div>
+            {{/if}}
+            {{#if doctor.cep}}
+              <div class="info-item">
+                <span class="info-label">CEP:</span>
+                <span class="info-value">{{cep doctor.cep}}</span>
               </div>
             {{/if}}
           </div>
@@ -200,7 +206,7 @@
           <div class="form-field">
             <label>CPF:</label>
             {{#if patient.document}}
-              <div class="field-value">{{patient.document}}</div>
+              <div class="field-value">{{cpfCnpj patient.document}}</div>
             {{else}}
               <div class="field-input"></div>
             {{/if}}
@@ -208,7 +214,15 @@
           <div class="form-field">
             <label>Telefone:</label>
             {{#if patient.phone}}
-              <div class="field-value">{{patient.phone}}</div>
+              <div class="field-value">{{phone patient.phone}}</div>
+            {{else}}
+              <div class="field-input"></div>
+            {{/if}}
+          </div>
+          <div class="form-field">
+            <label>CEP:</label>
+            {{#if patient.cep}}
+              <div class="field-value">{{cep patient.cep}}</div>
             {{else}}
               <div class="field-input"></div>
             {{/if}}

--- a/src/templates/medical/prescription.hbs
+++ b/src/templates/medical/prescription.hbs
@@ -132,7 +132,10 @@ author: Papyrus Team
               <div><strong>Clínica:</strong> {{doctor.clinic}}</div>
             {{/if}}
             {{#if doctor.phone}}
-              <div><strong>Telefone:</strong> {{doctor.phone}}</div>
+              <div><strong>Telefone:</strong> {{phone doctor.phone}}</div>
+            {{/if}}
+            {{#if doctor.cep}}
+              <div><strong>CEP:</strong> {{cep doctor.cep}}</div>
             {{/if}}
             {{#if doctor.address}}
               <div style="flex-basis: 100%">
@@ -164,6 +167,12 @@ author: Papyrus Team
                 <label>Peso:</label>
                 {{patient.weight}}
                 kg
+              </div>
+            {{/if}}
+            {{#if patient.cep}}
+              <div>
+                <label>CEP:</label>
+                {{cep patient.cep}}
               </div>
             {{/if}}
           </div>

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,0 +1,124 @@
+"use strict";
+
+const currencyFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function sanitizeNumericString(value) {
+  if (typeof value === "number") return value;
+  if (typeof value !== "string") {
+    return Number.isFinite(value) ? Number(value) : NaN;
+  }
+
+  const normalized = value
+    .replace(/[^0-9.,-]+/g, "")
+    .replace(/(?!^)-/g, "")
+    .replace(/\.(?=.*\.)/g, "")
+    .replace(/,/g, ".");
+
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : NaN;
+}
+
+function extractDigits(value) {
+  return (value ?? "")
+    .toString()
+    .replace(/\D+/g, "");
+}
+
+function formatCurrencyBRL(value) {
+  const parsed = sanitizeNumericString(value);
+  const safeValue = Number.isFinite(parsed) ? parsed : 0;
+  return currencyFormatter.format(safeValue);
+}
+
+function formatPhoneNumber(value) {
+  if (value === null || value === undefined) return "";
+
+  let digits = extractDigits(value);
+
+  if (digits.length >= 12 && digits.startsWith("55")) {
+    digits = digits.slice(2);
+  }
+
+  if (digits.length === 11) {
+    return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
+  }
+
+  if (digits.length === 10) {
+    return `(${digits.slice(0, 2)}) ${digits.slice(2, 6)}-${digits.slice(6)}`;
+  }
+
+  if (digits.length === 9) {
+    return `${digits.slice(0, 5)}-${digits.slice(5)}`;
+  }
+
+  if (digits.length === 8) {
+    return `${digits.slice(0, 4)}-${digits.slice(4)}`;
+  }
+
+  if (digits.length > 11) {
+    return formatPhoneNumber(digits.slice(0, 11));
+  }
+
+  return value.toString();
+}
+
+function formatCnpj(value) {
+  const digits = extractDigits(value);
+  if (digits.length !== 14) {
+    return value ?? "";
+  }
+
+  return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(
+    5,
+    8
+  )}/${digits.slice(8, 12)}-${digits.slice(12)}`;
+}
+
+function formatCpf(value) {
+  const digits = extractDigits(value);
+  if (digits.length !== 11) {
+    return value ?? "";
+  }
+
+  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(
+    6,
+    9
+  )}-${digits.slice(9)}`;
+}
+
+function formatCpfCnpj(value) {
+  const digits = extractDigits(value);
+
+  if (digits.length === 11) {
+    return formatCpf(digits);
+  }
+
+  if (digits.length === 14) {
+    return formatCnpj(digits);
+  }
+
+  return value ?? "";
+}
+
+function formatCep(value) {
+  const digits = extractDigits(value);
+  if (digits.length !== 8) {
+    return value ?? "";
+  }
+
+  return `${digits.slice(0, 5)}-${digits.slice(5)}`;
+}
+
+module.exports = {
+  formatCurrencyBRL,
+  formatPhoneNumber,
+  formatCnpj,
+  formatCpf,
+  formatCpfCnpj,
+  formatCep,
+};


### PR DESCRIPTION
## Summary
- adicionar utilitário centralizado para formatar moeda, telefone, CPF/CNPJ e CEP
- registrar helpers Handlebars para reutilizar as novas formatações nos templates
- aplicar as formatações nos orçamentos e documentos médicos, incluindo ajustes de CEP e valores monetários no template premium

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5472bd2c0832198f95b0b2ccd903d